### PR TITLE
Added persistence to minimized subpalettes

### DIFF
--- a/addons/scene_palette/components/sub_palette.gd
+++ b/addons/scene_palette/components/sub_palette.gd
@@ -2,6 +2,8 @@
 extends Control
 class_name PalettePluginSubPalette
 
+signal minimize_changed(value: bool)
+
 @export var arrow_closed:Texture2D
 @export var arrow_open:Texture2D
 
@@ -22,6 +24,20 @@ var expandable:bool = true:
 		if not expandable:
 			title_minimize_button.icon = null
 			title_minimize_button.disabled = true
+
+var minimized:bool = false:
+	set(value):
+		minimized = value
+		
+		if minimized:
+			title_minimize_button.icon = arrow_closed
+			content_container.hide()
+		else:
+			title_minimize_button.icon = arrow_open
+			content_container.show()
+
+		title_minimize_button.set_pressed_no_signal(minimized)
+		minimize_changed.emit(minimized)
 
 func set_title(title:String):
 	title_minimize_button.text = title.replace('-', ' ').replace('_', ' ')
@@ -65,12 +81,7 @@ func add_subpalette(palette:PalettePluginSubPalette):
 
 func _on_title_minimize_button_toggled(toggled_on):
 	if expandable:
-		if toggled_on:
-			title_minimize_button.icon = arrow_closed
-			content_container.hide()
-		else:
-			title_minimize_button.icon = arrow_open
-			content_container.show()
+		self.minimized = toggled_on		
 
 func _on_showin_file_system_button_pressed():
 	EditorInterface.get_file_system_dock().navigate_to_path(directory)

--- a/addons/scene_palette/palette.gd
+++ b/addons/scene_palette/palette.gd
@@ -68,6 +68,7 @@ var _current_dir:
 		# if we are navigating to a favorite, load saved settings for it
 		if _current_dir_in_favorites():
 			var save_data:PalettePluginSaveData = _get_save_data()
+			_clean_save_data() # clear any stale references to minimized directories
 			var favorite = save_data.favorites[_current_dir]
 			top_level_sub_palette.set_color(favorite.color)
 			toggle_on = favorite.instantiate_scenes_for_previews 
@@ -149,6 +150,17 @@ func _get_save_data() -> PalettePluginSaveData:
 		_create_new_save_data()
 		_populate_favorites_tab_bar()
 	return ResourceLoader.load(save_data_path)
+
+func _clean_save_data():
+	# Removes stale directory references
+	var save_data:PalettePluginSaveData = _get_save_data()
+	if _current_dir_in_favorites():
+		var favorite:Dictionary = save_data.favorites[_current_dir]
+		var minimized_dirs = favorite.get_or_add("minimized_dirs", {})
+		for path in minimized_dirs.keys():
+			if not DirAccess.dir_exists_absolute(path):
+				save_data.favorites[_current_dir]["minimized_dirs"].erase(path)
+		_save_data(save_data)
 
 func _save_data(data:PalettePluginSaveData):
 	ResourceSaver.save(data, save_data_path)

--- a/addons/scene_palette/palette.gd
+++ b/addons/scene_palette/palette.gd
@@ -105,8 +105,8 @@ func _populate_scenes(sub_palette:PalettePluginSubPalette, dir_path:String):
 			var path = dir_path + '/' + dir_name
 			sub_palette.add_subpalette(new_sub_palette)
 			new_sub_palette.directory = path
-			new_sub_palette.minimized = minimized_dirs.has(dir_name)
-			new_sub_palette.minimize_changed.connect(_on_sub_palette_minimize_changed.bind(dir_name))
+			new_sub_palette.minimized = minimized_dirs.has(path)
+			new_sub_palette.minimize_changed.connect(_on_sub_palette_minimize_changed.bind(path))
 			new_sub_palette.set_title(dir_name)
 			_populate_scenes(new_sub_palette, path)
 		for file_name in dir.get_files():

--- a/addons/scene_palette/resources/rsc_pallete_plugin_save_data.gd
+++ b/addons/scene_palette/resources/rsc_pallete_plugin_save_data.gd
@@ -12,5 +12,6 @@ func add_favorite(directory, instantiate_scenes, color=DEFAULT_BUTTON_COLOR):
 		instantiate_scenes_for_previews = instantiate_scenes,
 		color = color,
 		scene_preview_scale = 1,
-		show_labels = true
+		show_labels = true,
+		minimized_dirs = {}
 	}


### PR DESCRIPTION
a proposal for adding persistence to folding the subpalettes.
that's one less TODO on palette.gd!

let me know if you agree with my implementation. it should be backwards-compatible with old save files.