### PR TITLE
Added support for .scn files

### DIFF
--- a/addons/scene_palette/components/scene_thumbnail/scene_drop.gd
+++ b/addons/scene_palette/components/scene_thumbnail/scene_drop.gd
@@ -26,8 +26,20 @@ func show_file_label(show:bool):
 
 func _create_display_label(path:String) -> String:
 	var display_label = path.split('.tscn')[0].split('/')[-1]
+	if display_label == null:
+		display_label = path.split('.scn')[0].split('/')[-1]
 	display_label = display_label.replace('_', ' ').replace('-', ' ')
 	return display_label
+
+func _make_preview_for_scene() -> void:
+	if instantiate_scene_preview:
+			var node:Node = load(_scene_path).instantiate()
+			if _scene_is_safe(node):
+				picture_point.add_child(node)
+				return
+	# if scene is not safe to instantiate, just keep a preview
+	_make_preview()
+
 
 func set_scene(path:String):
 	tooltip_text = path
@@ -41,13 +53,9 @@ func set_scene(path:String):
 		'png':
 			texture_rect.texture = load(_scene_path)
 		'tscn':
-			if instantiate_scene_preview:
-					var node:Node = load(_scene_path).instantiate()
-					if _scene_is_safe(node):
-						picture_point.add_child(node)
-						return
-			# if scene is not safe to instantiate, just keep a preview
-			_make_preview()
+			_make_preview_for_scene()
+		'scn':
+			_make_preview_for_scene()
 		'obj':
 			_make_preview()
 

--- a/addons/scene_palette/components/scene_thumbnail/scene_drop.gd
+++ b/addons/scene_palette/components/scene_thumbnail/scene_drop.gd
@@ -25,9 +25,11 @@ func show_file_label(show:bool):
 	name_label.visible = show
 
 func _create_display_label(path:String) -> String:
-	var display_label = path.split('.tscn')[0].split('/')[-1]
-	if display_label == null:
-		display_label = path.split('.scn')[0].split('/')[-1]
+	var display_label = path.split('/')[-1]
+
+	display_label = path.split('.tscn')[0]
+	display_label = path.split('.scn')[0]
+
 	display_label = display_label.replace('_', ' ').replace('-', ' ')
 	return display_label
 
@@ -52,10 +54,14 @@ func set_scene(path:String):
 	match file_extension:
 		'png':
 			texture_rect.texture = load(_scene_path)
-		'tscn':
-			_make_preview_for_scene()
-		'scn':
-			_make_preview_for_scene()
+		'tscn', 'scn':
+			if instantiate_scene_preview:
+				var node:Node = load(_scene_path).instantiate()
+				if _scene_is_safe(node):
+					picture_point.add_child(node)
+					return
+			# if scene is not safe to instantiate, just keep a preview
+			_make_preview()
 		'obj':
 			_make_preview()
 

--- a/addons/scene_palette/components/scene_thumbnail/scene_drop.gd
+++ b/addons/scene_palette/components/scene_thumbnail/scene_drop.gd
@@ -33,16 +33,6 @@ func _create_display_label(path:String) -> String:
 	display_label = display_label.replace('_', ' ').replace('-', ' ')
 	return display_label
 
-func _make_preview_for_scene() -> void:
-	if instantiate_scene_preview:
-			var node:Node = load(_scene_path).instantiate()
-			if _scene_is_safe(node):
-				picture_point.add_child(node)
-				return
-	# if scene is not safe to instantiate, just keep a preview
-	_make_preview()
-
-
 func set_scene(path:String):
 	tooltip_text = path
 	_scene_path = path

--- a/addons/scene_palette/components/scene_thumbnail/scene_drop_holder.gd
+++ b/addons/scene_palette/components/scene_thumbnail/scene_drop_holder.gd
@@ -23,7 +23,7 @@ func set_scene(path:String):
 	name_label.tooltip_text = scene_name
 	
 	var file_extension = path.split('.')[-1]
-	if file_extension != 'tscn':
+	if file_extension != 'tscn' and file_extension != 'scn':
 		open_scene_button.hide()
 
 func _on_open_scene_button_pressed():

--- a/addons/scene_palette/palette.gd
+++ b/addons/scene_palette/palette.gd
@@ -41,7 +41,7 @@ var top_level_sub_palette:PalettePluginSubPalette
 const save_data_dir = "res://addons/scene_palette/save_data/"
 const save_data_path = save_data_dir + "save_data.tres"
 const pp = 'ScenePalettePlugin: ' # prepended to any printed messages
-const allowed_file_types = ['tscn', 'png', 'gltf', 'glb', 'fbx', 'obj']
+const allowed_file_types = ['scn', 'tscn', 'png', 'gltf', 'glb', 'fbx', 'obj']
 
 # signals to scene drops to indicate setting changes
 signal scene_scale_changed(amt:float)
@@ -127,7 +127,7 @@ func _populate_scenes(sub_palette:PalettePluginSubPalette, dir_path:String):
 		for file_name in dir.get_files():
 			var file_extension:String = file_name.split('.')[-1]
 			var all_file_types_allowed:bool = allow_file_types_button.button_pressed
-			if file_extension == 'tscn' or (all_file_types_allowed and file_extension in allowed_file_types):
+			if file_extension == 'tscn' or file_extension == 'scn' or (all_file_types_allowed and file_extension in allowed_file_types):
 				var scene_drop:PalettePluginSceneDrop = scene_drop_scene.instantiate()
 				sub_palette.add_item(scene_drop)
 				scene_drop.instantiate_scene_preview = instantiate_for_preview_button.button_pressed


### PR DESCRIPTION
Godot can store scenes in `.tscn` and `.scn` files.

I recently got an asset pack that's all .scn files and wanted to use it with this plugin. 

Pretty low-effort to get it all wired up, and it seems to work fine :)